### PR TITLE
Initialize directory config store before tests

### DIFF
--- a/configuration-it/config-service/src/main/java/io/vertx/openshift/it/ConfigurableHttpVerticle.java
+++ b/configuration-it/config-service/src/main/java/io/vertx/openshift/it/ConfigurableHttpVerticle.java
@@ -17,40 +17,52 @@ import io.vertx.ext.web.handler.StaticHandler;
 public class ConfigurableHttpVerticle extends AbstractVerticle {
 
   private ConfigRetriever retriever;
-  private JsonObject Config;
+  private JsonObject configByListen;
+  private JsonObject configByStream;
 
   @Override
   public void start() throws Exception {
     retriever = initializeConfig();
 
     retriever.getConfig(res -> {
-        if (res.failed()) {
-          throw new RuntimeException("Unable to retrieve the Config", res.cause());
+      if (res.failed()) {
+        throw new RuntimeException("Unable to retrieve the Config", res.cause());
+      } else {
+        configByStream = configByListen = (res.result() != null) ? res.result() : new JsonObject();
+      }
+    });
+
+    retriever.listen(change -> {
+      configByListen = change.getNewConfiguration();
+      System.out.println("A new config by listening to change has been used");
+    });
+
+    retriever.configStream()
+      .endHandler(event -> {
+        System.out.println("A config stream has been closed.");
+      })
+      .exceptionHandler(event -> {
+        System.err.println("An error has occurred: " + event.getMessage());
+        event.printStackTrace();
+      })
+      .handler(conf -> {
+        configByStream = conf;
+        System.out.println("A new config from stream has been used");
+    });
+
+    Router router = Router.router(vertx);
+    router.get("/all").handler(this::printAll);
+    router.get("/all-by-stream").handler(this::printConfigByStream);
+    router.get("/*").handler(StaticHandler.create("configuration"));
+    vertx.createHttpServer()
+      .requestHandler(router::accept)
+      .listen(8080, ar -> {
+        if (ar.succeeded()) {
+          System.out.println("Server listening on port " + ar.result().actualPort());
+        } else {
+          System.out.println("Unable to start the server: " + ar.cause().getMessage());
         }
-
-      Config = res.result();
-      if (Config == null) {
-        Config = new JsonObject();
-        }
-        retriever.listen(change -> {
-          Config = change.getNewConfiguration();
-          System.out.println("New Config:\n" + Config.encodePrettily());
-        });
-
-
-        Router router = Router.router(vertx);
-        router.get("/all").handler(this::printAll);
-        router.get("/*").handler(StaticHandler.create("configuration"));
-        vertx.createHttpServer()
-          .requestHandler(router::accept)
-          .listen(8080, ar -> {
-            if (ar.succeeded()) {
-              System.out.println("Server listening on port " + ar.result().actualPort());
-            } else {
-              System.out.println("Unable to start the server: " + ar.cause().getMessage());
-            }
-          });
-      });
+    });
   }
 
   @Override
@@ -61,7 +73,13 @@ public class ConfigurableHttpVerticle extends AbstractVerticle {
   private void printAll(RoutingContext rc) {
     rc.response()
       .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-      .end(Config.copy().put("trace", "1").encodePrettily());
+      .end(configByListen.copy().put("trace", "1").encodePrettily());
+  }
+
+  private void printConfigByStream(RoutingContext rc) {
+    rc.response()
+      .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+      .end(configByStream.copy().put("trace", "1").encodePrettily());
   }
 
   private ConfigRetriever initializeConfig() {
@@ -126,6 +144,7 @@ public class ConfigurableHttpVerticle extends AbstractVerticle {
         .addStore(dir)
         .addStore(jsonFile)
         .addStore(ymlFile)
+        .setScanPeriod(10000)
     );
   }
 }

--- a/configuration-it/hazelcast-config/cluster.xml
+++ b/configuration-it/hazelcast-config/cluster.xml
@@ -38,7 +38,9 @@
         <multicast-port>54327</multicast-port>
       </multicast>
 
-      <tcp-ip enabled="false"/>
+      <tcp-ip enabled="true">
+        <interface>192.168.1.*</interface>
+      </tcp-ip>
       <discovery-strategies>
         <discovery-strategy enabled="true"
                             class="io.vertx.servicediscovery.hazelcast.HazelcastKubernetesDiscoveryStrategy">

--- a/configuration-it/integration-tests/pom.xml
+++ b/configuration-it/integration-tests/pom.xml
@@ -17,6 +17,15 @@
     <vertx.health.path>/</vertx.health.path>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx.openshift</groupId>
+      <artifactId>config-service</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <profiles>
     <profile>
       <id>openshift</id>

--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,10 @@
 
      they are very outdated.
      -->
-    <fabric8.maven.plugin.version>3.5.0</fabric8.maven.plugin.version>
+    <fabric8.maven.plugin.version>3.5.25</fabric8.maven.plugin.version>
     <!-- must use version from https://maven.repository.redhat.com/ga/io/fabric8/kubernetes-client/ -->
     <!-- TODO update kubernetes.client.version to 1.4.35 - currently we have a kubernetes client conflict, see OpenShiftTestAssistant.java -->
-    <kubernetes.client.version>1.4.14</kubernetes.client.version>
+    <kubernetes.client.version>1.4.35</kubernetes.client.version>
 
     <!-- muse use version from https://maven.repository.redhat.com/ga/io/fabric8/kubernetes-api/ -->
     <kubernetes.api.version>2.2.170</kubernetes.api.version>


### PR DESCRIPTION
Because we're deploying the configuration service to OpenShift, the config service jar file from is run from `/deployments` directory in a pod, not from our local machine, so directory config store wouldn't work without this - it wouldn't find the configs. That's why we have to copy them to the `/deployments` dir in config-service pod.