### PR TITLE
Fixed usage of deprecated method

### DIFF
--- a/various-db-engines-it/db-it/pom.xml
+++ b/various-db-engines-it/db-it/pom.xml
@@ -33,9 +33,9 @@
   </dependencies>
 
   <profiles>
-    <!-- external-db-tests profile expects a db connection and oracle jdbc artifact to be provided.
-         This profile is active by default. -->
     <profile>
+      <!-- external-db-tests profile expects a db connection and oracle jdbc artifact to be provided.
+      This profile is active by default. -->
       <id>external-db-tests</id>
       <properties>
         <externalDb>true</externalDb>

--- a/various-db-engines-it/db-it/pom.xml
+++ b/various-db-engines-it/db-it/pom.xml
@@ -33,6 +33,8 @@
   </dependencies>
 
   <profiles>
+    <!-- external-db-tests profile expects a db connection and oracle jdbc artifact to be provided.
+         This profile is active by default. -->
     <profile>
       <id>external-db-tests</id>
       <properties>
@@ -69,10 +71,17 @@
     </profile>
 
     <profile>
+      <!-- internal-db-tests profile also deploys relevant db images (postgresql & mysql) on OpenShift. Oracle db image
+      is not available, that's why this module is excluded from the build. -->
       <id>internal-db-tests</id>
       <properties>
         <externalDb>false</externalDb>
       </properties>
+      <!-- Only build modules for which we have OpenShift db images -->
+      <modules>
+        <module>mysql-it</module>
+        <module>postgresql-it</module>
+      </modules>
       <build>
         <plugins>
           <plugin>

--- a/various-db-engines-it/verticle-utils/src/main/java/io/vertx/openshift/utils/AbstractDBTestClass.java
+++ b/various-db-engines-it/verticle-utils/src/main/java/io/vertx/openshift/utils/AbstractDBTestClass.java
@@ -68,6 +68,6 @@ public class AbstractDBTestClass extends AbstractTestClass {
   }
 
   private RequestSpecification setRequestJSONBody(JSONObject body) {
-    return given().content(ContentType.JSON).body(body.toString());
+    return given().body(ContentType.JSON).body(body.toString());
   }
 }


### PR DESCRIPTION
Excluded oracle-it submodule from build when running internal-db-tests profile in various-db-engines-it module