### PR TITLE
Create maven property for setting selenium/stadalone-chrome image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,12 @@ You need to set up maven properties, which are used for openshift route generati
 
 
 ## SockJS service proxy
-Integration tests for sockjs-service-proxy module (RPC-like application)
+Integration tests for sockjs-service-proxy module (RPC-like application).
+
+If this test fail on `SockJSProxyIT.initialize:34`  please try to change [selenium/standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome/) version by maven property: 
+* `chrome.selenium.image.version`. 
+  * Default value this property is set to `latest`
+  * Latest known working version on openshift is `3.14.0-europium`
 
 
 ## SSO Auth

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,9 @@
     <fabric8.dockerUser>vertx-openshift-it</fabric8.dockerUser>
     <docker.image>${docker.group.name}/${project.artifactId}:${project.version}</docker.image>
     <vertx.health.path>/</vertx.health.path>
+
+    <!-- selenium/standalone-chrome image version-->
+    <chrome.selenium.image.version>latest</chrome.selenium.image.version>
   </properties>
 
   <modules>

--- a/vertx-it-utils/src/main/java/io/vertx/it/openshift/utils/ChromeDeployment.java
+++ b/vertx-it-utils/src/main/java/io/vertx/it/openshift/utils/ChromeDeployment.java
@@ -25,6 +25,7 @@ public class ChromeDeployment implements AutoCloseable {
   private Pod pod;
   private Service service;
   private WebDriver driver;
+  private static final String CHROME_SELENIUM_IMAGE_VERSION = System.getProperty("chrome.selenium.image.version","latest");
 
   public ChromeDeployment(OpenShiftClient client) {
     this.client = client;
@@ -83,12 +84,11 @@ public class ChromeDeployment implements AutoCloseable {
     if (!retrievePod()) {
       Container c = new ContainerBuilder()
         .withName(CHROME)
-        .withImage("selenium/standalone-chrome")
+        .withImage("selenium/standalone-chrome:" + CHROME_SELENIUM_IMAGE_VERSION)
         .withImagePullPolicy("Always")
         .withEnv(new EnvVar("IGNORE_SSL_ERRORS", "true", null))
         .withPorts(new ContainerPortBuilder().withContainerPort(4444).withName("webdriver").build())
         .build();
-
       Pod pb = new PodBuilder()
         .withNewMetadata()
         .withName(CHROME)


### PR DESCRIPTION
I don't find any workaround for issue https://github.com/SeleniumHQ/docker-selenium so I create maven property for setting version of selenium/standalone-chrome image.
(Versions 3.14.0-francium and 3.14.0-gallium don't work)
@spisiakm Please review. 